### PR TITLE
fix: Allow Windows compatible line endings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,12 @@ module.exports = {
   },
   plugins: ["@babel", "react", "react-hooks", "prettier"],
   rules: {
-    "prettier/prettier": "error",
+    "prettier/prettier": [
+      "error",
+      {
+        endOfLine: "auto",
+      },
+    ],
     "react/no-find-dom-node": "off",
   },
 }


### PR DESCRIPTION
Fixes an error with prettier configuration when editing or building files with Unix line endings on a machine with Windows OS. Windows expects CRLF so this error is thrown out:

```error  Delete `␍`  prettier/prettier```

This change to EsLint prettier rule fixes this error.